### PR TITLE
fix: override env vars with local .env in demo data generator

### DIFF
--- a/scripts/generate_demo_data.py
+++ b/scripts/generate_demo_data.py
@@ -1950,7 +1950,7 @@ Available providers:
         return
 
     # Load environment variables
-    load_dotenv(os.path.join(os.path.dirname(__file__), '..', '.env'))
+    load_dotenv(os.path.join(os.path.dirname(__file__), '..', '.env'), override=True)
 
     # Validate environment
     if not os.getenv("POSTHOG_API_KEY"):


### PR DESCRIPTION
## Summary
- Adds `override=True` to `load_dotenv()` in the demo data generator so the local `.env` always wins over inherited env vars (e.g. from Claude Code session settings)

## Context
Claude Code injects `POSTHOG_API_KEY` and `POSTHOG_HOST` env vars for its own telemetry plugin. Since `load_dotenv()` doesn't override existing env vars by default, the demo generator was silently sending traces to cloud PostHog instead of localhost during local dev.