### PR TITLE
fix(examples): bypass cache when running a single example directly

### DIFF
--- a/run-examples.sh
+++ b/run-examples.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 #   ./run-examples.sh --install                 Install deps for all examples
 #   ./run-examples.sh --rerun                   Force re-run (ignore cache), combinable with other flags
 #   ./run-examples.sh --reset                   Clear the results cache
-#   ./run-examples.sh openai/embeddings         Run a specific example (fuzzy match)
+#   ./run-examples.sh openai/embeddings         Run a specific example (fuzzy match, bypasses cache)
 #   ./run-examples.sh anthropic                 Run all examples matching "anthropic"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -473,6 +473,8 @@ elif [[ -n "$MODE" && "$MODE" != --* ]]; then
         echo "Use --list to see all available examples."
         exit 1
     elif [[ ${#MATCHED[@]} -eq 1 ]]; then
+        # Running a single example directly always bypasses the cache.
+        RERUN=1
         run_example "${MATCHED[0]}"
     else
         echo "Running ${#MATCHED[@]} examples matching '$MODE':"


### PR DESCRIPTION
## Problem

When invoking `run-examples.sh` with a name filter that resolves to exactly one example (e.g. `./run-examples.sh openai/embeddings`), the runner would silently skip execution if the example was already cached from a previous passing run. If you're running a specific example by name, you almost certainly want it to actually run.

## Changes

- Set `RERUN=1` in the single-match branch of the name-based matcher so the cache check is bypassed.
- Updated the usage comment to note that a specific example bypasses the cache.

Batch runs (`--all`, `--parallel`, or fuzzy filters matching multiple examples) still respect the cache.

## How did you test this code?

Manual: ran `./run-examples.sh <name>` for a cached example and confirmed it re-executed rather than reporting "cached".

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*